### PR TITLE
fix missing comma in readme sample

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ In your `config/ColdBox.cfc` create a `cbfs` structure within the `moduleSetting
 ```js
 moduleSettings = {
 	"cbfs": {
-		"defaultDisk" : "default"
+		"defaultDisk" : "default",
 		"disks": {
 			"default": {
 				"provider": "LocalProvider@cbfs"


### PR DESCRIPTION
missing comma in readme.md for ColdBox moduleSettings example