### PR TITLE
Resolves Issue #20

### DIFF
--- a/models/providers/LocalProvider.cfc
+++ b/models/providers/LocalProvider.cfc
@@ -127,12 +127,19 @@ component accessors="true" extends="cbfs.models.AbstractDiskProvider" {
 			ensureDirectoryExists( containerDirectory );
 		}
 
-		// Write it
-		variables.jFiles.write(
-			buildJavaDiskPath( arguments.path ),
-			arguments.contents.getBytes(),
-			[]
-		);
+		// Use native method if binary, as it's less verbose than creating an input stream and getting the bytes
+		if( isBinary( arguments.contents ) ){
+			fileWrite(
+				arguments.path,
+				arguments.contents
+			);
+		} else {
+			variables.jFiles.write(
+				buildJavaDiskPath( arguments.path ),
+				arguments.contents.getBytes(),
+				[]
+			);
+		}
 
 		// Set visibility or mode
 		if ( isWindows() ) {

--- a/models/providers/LocalProvider.cfc
+++ b/models/providers/LocalProvider.cfc
@@ -128,11 +128,8 @@ component accessors="true" extends="cbfs.models.AbstractDiskProvider" {
 		}
 
 		// Use native method if binary, as it's less verbose than creating an input stream and getting the bytes
-		if( isBinary( arguments.contents ) ){
-			fileWrite(
-				arguments.path,
-				arguments.contents
-			);
+		if ( isBinary( arguments.contents ) ) {
+			fileWrite( arguments.path, arguments.contents );
 		} else {
 			variables.jFiles.write(
 				buildJavaDiskPath( arguments.path ),


### PR DESCRIPTION
Using the native CF method is much less verbose than trying to obtain the byte array from the binary object to pass in to java.nio.file.Files.  We can refactor this later, if you wish, but Issue #20 is a blocker for using cbfs until `create` can accept binary files.