### PR TITLE
Patch/Fix Empty Disk URL handling

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -38,12 +38,15 @@ component {
 				"public" : {
 					provider   : "Local",
 					properties : {
-						path    : getSystemSetting( "CBFS_PUBLIC_DISK_PATH", "#controller.getAppRootPath()#includes/public" ),
+						path : getSystemSetting(
+							"CBFS_PUBLIC_DISK_PATH",
+							"#controller.getAppRootPath()#includes/public"
+						),
 						diskUrl : function(){
 							return variables.controller
-									.getRequestService()
-									.getContext()
-									.getHtmlBaseUrl() & "includes/public"
+								.getRequestService()
+								.getContext()
+								.getHtmlBaseUrl() & "includes/public"
 						}
 					}
 				},

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -38,17 +38,19 @@ component {
 				"public" : {
 					provider   : "Local",
 					properties : {
-						path    : "#controller.getAppRootPath()#includes/public",
-						diskUrl : controller
-							.getRequestService()
-							.getContext()
-							.getHtmlBaseUrl() & "includes/public"
+						path    : getSystemSetting( "CBFS_PUBLIC_DISK_PATH", "#controller.getAppRootPath()#includes/public" ),
+						diskUrl : function(){
+							return variables.controller
+									.getRequestService()
+									.getContext()
+									.getHtmlBaseUrl() & "includes/public"
+						}
 					}
 				},
 				// A disk that points to the CFML Engine's temp directory
 				"temp" : {
 					provider   : "Local",
-					properties : { path : getTempDirectory() }
+					properties : { path : getSystemSetting( "CBFS_TEMP_DISK_PATH", getTempDirectory() ) }
 				}
 			}
 		};

--- a/models/providers/LocalProvider.cfc
+++ b/models/providers/LocalProvider.cfc
@@ -671,18 +671,18 @@ component accessors="true" extends="cbfs.models.AbstractDiskProvider" {
 	 * @path The file path to build the URL with
 	 */
 	string function url( required string path ){
-		if( isNull( variables.properties.diskUrl ) ){
+		if ( isNull( variables.properties.diskUrl ) ) {
 			throw(
 				message = "This implementation for disk #variables.name# does not support retreiving URLs. Please provide a `diskUrl` configuration string or closure to allow URL generation.",
-				type = "cbfs.UnsupportedMethodException"
+				type    = "cbfs.UnsupportedMethodException"
 			);
 		}
 		return (
-				isClosure( variables.properties.diskUrl )
-					? variables.properties.diskUrl()
-					: variables.properties.diskUrl
-				)
-				& arguments.path;
+			isClosure( variables.properties.diskUrl )
+			 ? variables.properties.diskUrl()
+			 : variables.properties.diskUrl
+		)
+		& arguments.path;
 	}
 
 	/**

--- a/models/providers/LocalProvider.cfc
+++ b/models/providers/LocalProvider.cfc
@@ -78,6 +78,13 @@ component accessors="true" extends="cbfs.models.AbstractDiskProvider" {
 			if ( !reFind( "\/$", variables.properties.diskUrl ) ) {
 				variables.properties.diskUrl &= "/";
 			}
+		} else {
+			variables.properties.diskURL = variables.requestService.getContext().getHTMLBaseURL()
+								& replace(
+									variables.properties.path,
+									variables.wirebox.getInstance( "coldbox" ).getSetting( "ApplicationPath" ),
+									""
+								) & "/" ;
 		}
 
 		// Verify the disk storage exists, else create it

--- a/models/providers/LocalProvider.cfc
+++ b/models/providers/LocalProvider.cfc
@@ -80,11 +80,11 @@ component accessors="true" extends="cbfs.models.AbstractDiskProvider" {
 			}
 		} else {
 			variables.properties.diskURL = variables.requestService.getContext().getHTMLBaseURL()
-								& replace(
-									variables.properties.path,
-									variables.wirebox.getInstance( "coldbox" ).getSetting( "ApplicationPath" ),
-									""
-								) & "/" ;
+			& replace(
+				variables.properties.path,
+				variables.wirebox.getInstance( "coldbox" ).getSetting( "ApplicationPath" ),
+				""
+			) & "/";
 		}
 
 		// Verify the disk storage exists, else create it

--- a/models/providers/LocalProvider.cfc
+++ b/models/providers/LocalProvider.cfc
@@ -25,7 +25,7 @@ component accessors="true" extends="cbfs.models.AbstractDiskProvider" {
 		// The public disk Url. This is used to create file urls and temporary urls
 		// This should point to the root path but in a web accessible format
 		// It should remain empty if the disk is not web accessible
-		diskUrl          : ""
+		diskUrl          : javacast( "null", 0 )
 	};
 	// Java Helpers
 	// @see https://docs.oracle.com/javase/8/docs/api/java/nio/file/Paths.html#get-java.lang.String-java.lang.String...-
@@ -74,17 +74,10 @@ component accessors="true" extends="cbfs.models.AbstractDiskProvider" {
 		variables.properties.jPath = getJavaPath( arguments.properties.path );
 
 		// Make sure if you have a diskurl, that it ends in a slash
-		if ( len( variables.properties.diskUrl ) ) {
+		if ( !isNull( variables.properties.diskUrl ) && !isClosure( variables.properties.diskUrl ) ) {
 			if ( !reFind( "\/$", variables.properties.diskUrl ) ) {
 				variables.properties.diskUrl &= "/";
 			}
-		} else {
-			variables.properties.diskURL = variables.requestService.getContext().getHTMLBaseURL()
-			& replace(
-				variables.properties.path,
-				variables.wirebox.getInstance( "coldbox" ).getSetting( "ApplicationPath" ),
-				""
-			) & "/";
 		}
 
 		// Verify the disk storage exists, else create it
@@ -678,7 +671,18 @@ component accessors="true" extends="cbfs.models.AbstractDiskProvider" {
 	 * @path The file path to build the URL with
 	 */
 	string function url( required string path ){
-		return variables.properties.diskUrl & arguments.path;
+		if( isNull( variables.properties.diskUrl ) ){
+			throw(
+				message = "This implementation for disk #variables.name# does not support retreiving URLs. Please provide a `diskUrl` configuration string or closure to allow URL generation.",
+				type = "cbfs.UnsupportedMethodException"
+			);
+		}
+		return (
+				isClosure( variables.properties.diskUrl )
+					? variables.properties.diskUrl()
+					: variables.properties.diskUrl
+				)
+				& arguments.path;
 	}
 
 	/**


### PR DESCRIPTION
- Changes to allow a closure for the `diskUrl` setting
- Will now throw an error if `diskUrl` is null and the `url` method is invoked.