### PR TITLE
CONTENTBOX-1495 - fix for windows path issue in contentbox

### DIFF
--- a/models/providers/LocalProvider.cfc
+++ b/models/providers/LocalProvider.cfc
@@ -65,6 +65,7 @@ component accessors="true" extends="cbfs.models.AbstractDiskProvider" {
 			);
 		}
 
+		variables.properties.path = normalizePath(variables.properties.path);
 		// Do we need to expand the path
 		if ( variables.properties.autoExpand ) {
 			variables.properties.path = expandPath( variables.properties.path );
@@ -1426,8 +1427,8 @@ component accessors="true" extends="cbfs.models.AbstractDiskProvider" {
 	 * @return The canonical path on the disk
 	 */
 	function buildDiskPath( string path = "" ){
-		return arguments.path.startsWith( variables.properties.path )
-		 ? arguments.path
+		return normalizePath( arguments.path ).startsWith( variables.properties.path )
+		 ? normalizePath( arguments.path )
 		 : reReplace(
 			variables.properties.path & "/#normalizePath( arguments.path )#",
 			"\/$",


### PR DESCRIPTION
# Description

Convert \ to / when comparing file paths in the LocalProvider startup() and info() methods, so that the comparison works as expected on Windows.

## Issues

https://ortussolutions.atlassian.net/browse/CONTENTBOX-1495
In cbfs the normalisation of file paths to use / instead of \ is incomplete. The error only happens on windows.

## Type of change

Bug Fix
